### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/6502.c
+++ b/examples/6502.c
@@ -1,5 +1,5 @@
 //
-// -- A 6502 compiler specalizing in 16-bit integer math and brute force loop unrolling --
+// -- A 6502 compiler specializing in 16-bit integer math and brute force loop unrolling --
 //
 
 #include <str.h>
@@ -1091,7 +1091,7 @@ compile(char* code)
 void
 boids(void)
 {
-    // This program simluates 9 boids starting in random positions and
+    // This program simulates 9 boids starting in random positions and
     // move in random velocities while avoid one another. Boids bounce
     // off the edge of the screen.
     compile(


### PR DESCRIPTION
There are small typos in:
- examples/6502.c

Fixes:
- Should read `specializing` rather than `specalizing`.
- Should read `simulates` rather than `simluates`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md