### PR TITLE
change internal includes from "angle bracket" to "quote form"

### DIFF
--- a/ctl/deq.h
+++ b/ctl/deq.h
@@ -6,7 +6,7 @@
 #error "Template type T undefined for <deq.h>"
 #endif
 
-#include <ctl.h>
+#include "ctl.h"
 
 #define A JOIN(deq, T)
 #define B JOIN(A, bucket)

--- a/ctl/lst.h
+++ b/ctl/lst.h
@@ -6,7 +6,7 @@
 #error "Template type T undefined for <lst.h>"
 #endif
 
-#include <ctl.h>
+#include "ctl.h"
 
 #define A JOIN(lst, T)
 #define B JOIN(A, node)

--- a/ctl/pqu.h
+++ b/ctl/pqu.h
@@ -34,7 +34,7 @@
 #define HOLD
 #define COMPARE
 #define init __INIT
-#include <vec.h>
+#include "vec.h"
 #undef init
 #undef vec
 

--- a/ctl/que.h
+++ b/ctl/que.h
@@ -26,7 +26,7 @@
 #define remove_if   __REMOVE_IF
 
 #define deq que
-#include <deq.h>
+#include "deq.h"
 #undef deq
 
 #undef push_back

--- a/ctl/set.h
+++ b/ctl/set.h
@@ -6,7 +6,7 @@
 #error "Template type T undefined for <set.h>"
 #endif
 
-#include <ctl.h>
+#include "ctl.h"
 
 #define A JOIN(set, T)
 #define B JOIN(A, node)

--- a/ctl/stk.h
+++ b/ctl/stk.h
@@ -28,7 +28,7 @@
 #define remove_if   __REMOVE_IF
 
 #define deq stk
-#include <deq.h>
+#include "deq.h"
 #undef deq
 
 #undef push_back

--- a/ctl/str.h
+++ b/ctl/str.h
@@ -16,7 +16,7 @@
 #define str_equal str___EQUAL
 #define str_find str___FIND
 #define str_copy str___COPY
-#include <vec.h>
+#include "vec.h"
 #undef str_init
 #undef str_copy
 #undef str_equal

--- a/ctl/ust.h
+++ b/ctl/ust.h
@@ -6,7 +6,7 @@
 #error "Template type T undefined for <ust.h>"
 #endif
 
-#include <ctl.h>
+#include "ctl.h"
 
 #define A JOIN(ust, T)
 #define B JOIN(A, node)

--- a/ctl/vec.h
+++ b/ctl/vec.h
@@ -6,7 +6,7 @@
 #error "Template type T undefined for <vec.h>"
 #endif
 
-#include <ctl.h>
+#include "ctl.h"
 
 #define A JOIN(vec, T)
 #define Z JOIN(A, it)


### PR DESCRIPTION
here is a tardy pull request for something like
----
https://github.com/glouw/ctl/issues/25#issuecomment-2364968883
----

so that if the directory is not in the --include list, they can include each other.

ctl/deq.h:
ctl/lst.h:
ctl/pqu.h:
ctl/que.h:
ctl/set.h:
ctl/stk.h:
ctl/str.h:
ctl/ust.h:
ctl/vec.h:

apparently there are arguments on both sides:

https://stackoverflow.com/a/72065059/1527747

https://github.com/isocpp/CppCoreGuidelines/pull/1596#issuecomment-1113901271